### PR TITLE
Fix typo in project tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -429,7 +429,7 @@
           <h3>Distributed Lamport chat</h3>
           <p>A distributed messaging system implementing Lamport clocks and total order broadcast using the ISIS algorithm. Designed for academic exploration of distributed systems behavior.</p>
           <div class="tags">
-            <span>Pyhton</span><span>Shell</span>
+            <span>Python</span><span>Shell</span>
           </div>
           <a href="https://github.com/Uriel-Gz/distributed_lamport_chat" 
           target="_blank" class="github-btn"


### PR DESCRIPTION
## Summary
- fix misspelled **Python** tag on Distributed Lamport chat card

## Testing
- `grep -n "Pyhton" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6841c3720e34832391cffa1555dd7d82