### PR TITLE
Fix comment spacing in meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon/favicon-16x16.png">
   
-    <!-- Social OpenGraph -->
+    <!-- Social Open Graph -->
     <meta property="og:title" content="Juani's Website">
     <meta property="og:description" content="Hey! I’m Juani: CS student, web developer, and builder of cool Flutter apps that work everywhere. Come check out my projects!">
     <meta property="og:type" content="website">


### PR DESCRIPTION
## Summary
- update the comment for Open Graph meta tags so it reads `Social Open Graph`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841c38cd55c832386545a11bb931d01