### PR TITLE
Fix mislinked repo URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,13 +120,13 @@
         "description": "A Progressive Web App designed for the Facultad de Ciencias Económicas at UNRC, integrating Moodle content and providing a seamless mobile-friendly interface for students and staff.",
         "programmingLanguage": "JS, HTML, JSON",
         "skills": ["JavaScript", "HTML", "JSON", "Progressive Web App", "Moodle integration"],
-        "url": "https://github.com/JuaniV2002/moodle_welcome_message_plugin",
+        "url": "https://github.com/JuaniV2002/EcosistemaFCE_PWA",
         "offers": {
           "@type": "Offer",
           "price": "0",
           "priceCurrency": "USD",
           "availability": "https://schema.org/InStock",
-          "url": "https://github.com/JuaniV2002/moodle_welcome_message_plugin"
+          "url": "https://github.com/JuaniV2002/EcosistemaFCE_PWA"
         },
         "aggregateRating": {
           "@type": "AggregateRating",
@@ -150,13 +150,13 @@
         "description": "A custom Moodle plugin that automatically sends a welcome email, web notification, and mobile push notification to new users upon enrollment—fully integrated with the Moodle App.",
         "programmingLanguage": "PHP, CSS",
         "skills": ["PHP", "CSS", "Moodle plugin development", "Email automation", "Push notifications"],
-        "url": "https://github.com/JuaniV2002/EcosistemaFCE_PWA",
+        "url": "https://github.com/JuaniV2002/moodle_welcome_message_plugin",
         "offers": {
           "@type": "Offer",
           "price": "0",
           "priceCurrency": "USD",
           "availability": "https://schema.org/InStock",
-          "url": "https://github.com/JuaniV2002/EcosistemaFCE_PWA"
+          "url": "https://github.com/JuaniV2002/moodle_welcome_message_plugin"
         },
         "aggregateRating": {
           "@type": "AggregateRating",
@@ -378,7 +378,7 @@
           <div class="tags">
             <span>JS</span><span>HTML</span><span>JSON</span>
           </div>
-          <a href="https://github.com/JuaniV2002/moodle_welcome_message_plugin" 
+          <a href="https://github.com/JuaniV2002/EcosistemaFCE_PWA" 
           target="_blank" class="github-btn" 
           aria-label="View Ecosistema FCE PWA on GitHub">
             <img src="assets/icons/github.svg" alt="GitHub" class="icon-github">
@@ -391,7 +391,7 @@
           <div class="tags">
             <span>PHP</span><span>CSS</span>
           </div>
-          <a href="https://github.com/JuaniV2002/EcosistemaFCE_PWA" 
+          <a href="https://github.com/JuaniV2002/moodle_welcome_message_plugin" 
           target="_blank" class="github-btn"
           aria-label="View Moodle Welcome Message on GitHub">
             <img src="assets/icons/github.svg" alt="GitHub" class="icon-github">


### PR DESCRIPTION
## Summary
- fix incorrect GitHub links for Ecosistema FCE PWA
- fix incorrect GitHub links for Moodle Welcome Message

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841c384ec088323a3d4fa0104a53e24